### PR TITLE
Clean APA102 SPI code

### DIFF
--- a/avr/cores/AutomaTile/APA102C.c
+++ b/avr/cores/AutomaTile/APA102C.c
@@ -15,6 +15,7 @@ void setPort(volatile uint8_t* port){
 }
 
 //bit bangs an SPI signal to the specified pins of the given data
+static void sendByte( uint8_t data){
     
     uint8_t bitmask = 0b10000000;
     

--- a/avr/cores/AutomaTile/APA102C.c
+++ b/avr/cores/AutomaTile/APA102C.c
@@ -22,7 +22,7 @@ void setPort(volatile uint8_t* port){
 }
 
 //bit bangs an SPI signal to the specified pins of the given data
-static void sendBit(uint8_t clkPin, uint8_t datPin, uint8_t data){
+static void sendBit( uint8_t data){
     
     uint8_t bitmask = 0b10000000;
     
@@ -46,15 +46,15 @@ static void sendBit(uint8_t clkPin, uint8_t datPin, uint8_t data){
  }    
  
 //bit bangs an SPI signal to the specified pins of the given data
-void sendByte(uint8_t clkPin, uint8_t datPin, uint8_t data){
-	sendBit(clkPin, datPin, bit_val(data,7));
-	sendBit(clkPin, datPin, bit_val(data,6));
-	sendBit(clkPin, datPin, bit_val(data,5));
-	sendBit(clkPin, datPin, bit_val(data,4));
-	sendBit(clkPin, datPin, bit_val(data,3));
-	sendBit(clkPin, datPin, bit_val(data,2));
-	sendBit(clkPin, datPin, bit_val(data,1));
-	sendBit(clkPin, datPin, bit_val(data,0));
+void sendByte(uint8_t data){
+	sendBit( bit_val(data,7));
+	sendBit( bit_val(data,6));
+	sendBit( bit_val(data,5));
+	sendBit( bit_val(data,4));
+	sendBit( bit_val(data,3));
+	sendBit( bit_val(data,2));
+	sendBit( bit_val(data,1));
+	sendBit( bit_val(data,0));
 }
 //bit bangs an SPI signal to the specified pins that generates the specified color 
 //	formatted for the APA102, provided as a byte array of R,G,B
@@ -63,13 +63,13 @@ void sendColor(uint8_t clkPin, uint8_t datPin,const rgb c){
 		return;
 	}
 	//Start Frame
-	sendByte(clkPin, datPin, 0x00);
-	sendByte(clkPin, datPin, 0x00);
-	sendByte(clkPin, datPin, 0x00);
-	sendByte(clkPin, datPin, 0x00);
+	sendByte( 0x00);
+	sendByte( 0x00);
+	sendByte( 0x00);
+	sendByte( 0x00);
 	//Data
-	sendByte(clkPin, datPin, 0xE1);//Set brightness to current to minimum TODO: Add setBrightness function (0xE1...0xFF)
-	sendByte(clkPin, datPin, c.b);
-	sendByte(clkPin, datPin, c.g);
-	sendByte(clkPin, datPin, c.r);
+	sendByte( 0xE1);//Set brightness to current to minimum TODO: Add setBrightness function (0xE1...0xFF)
+	sendByte( c.b);
+	sendByte( c.g);
+	sendByte( c.r);
 }

--- a/avr/cores/AutomaTile/APA102C.c
+++ b/avr/cores/AutomaTile/APA102C.c
@@ -11,18 +11,10 @@
 
 #include "Pins.h"
 
-#define set(port,pin) (port |= pin) // set port pin
-#define clear(port,pin) (port &= (~pin)) // clear port pin
-#define bit_val(byte,bit) (byte & (1 << bit)) // test for bit set
-
-uint8_t portSet = 0;
 void setPort(volatile uint8_t* port){
-	portSet = 1;
-	SPI_PORT = port;
 }
 
 //bit bangs an SPI signal to the specified pins of the given data
-static void sendBit( uint8_t data){
     
     uint8_t bitmask = 0b10000000;
     
@@ -45,23 +37,9 @@ static void sendBit( uint8_t data){
     }
  }    
  
-//bit bangs an SPI signal to the specified pins of the given data
-void sendByte(uint8_t data){
-	sendBit( bit_val(data,7));
-	sendBit( bit_val(data,6));
-	sendBit( bit_val(data,5));
-	sendBit( bit_val(data,4));
-	sendBit( bit_val(data,3));
-	sendBit( bit_val(data,2));
-	sendBit( bit_val(data,1));
-	sendBit( bit_val(data,0));
-}
 //bit bangs an SPI signal to the specified pins that generates the specified color 
 //	formatted for the APA102, provided as a byte array of R,G,B
 void sendColor(uint8_t clkPin, uint8_t datPin,const rgb c){
-	if(!portSet){
-		return;
-	}
 	//Start Frame
 	sendByte( 0x00);
 	sendByte( 0x00);

--- a/avr/cores/AutomaTile/APA102C.h
+++ b/avr/cores/AutomaTile/APA102C.h
@@ -13,8 +13,8 @@
 
 #include "color.h"
 
-void setPort(volatile uint8_t* port);
 void sendColor(uint8_t clkPin, uint8_t datPin,const rgb c);
-volatile uint8_t* SPI_PORT;
+
+void setPort(volatile uint8_t* port);           // TODO: THis is unused, but there are calls to it with no prototype that need to be dealt with
 
 #endif /* APA102C_H_ */

--- a/avr/cores/AutomaTile/Pins.h
+++ b/avr/cores/AutomaTile/Pins.h
@@ -18,6 +18,8 @@
 //IR LED output pin
 #define IR (1<<PB2)
 //LED clock and data pins
+
+#define LEDPORT PORTB
 #define LEDCLK (1<<PB0)
 #define LEDDAT (1<<PB1)
 //Microphone pin


### PR DESCRIPTION
Non-breaking change.

Cleaned up the processing of the SPI bits going to the pixel, saved 174 bytes flash and big performance improvement. 

## Flash Size Impact
```
3964 bytes before
3790 bytes after
====
0174 bytes decrease
```
