### PR TITLE
Fix potential short out, add 3 blue blinks as startup indication

### DIFF
--- a/avr/cores/AutomaTile/AutomaTile.c
+++ b/avr/cores/AutomaTile/AutomaTile.c
@@ -606,8 +606,8 @@ ISR(TIM0_COMPA_vect){
 				wake=3;
 			}
 		}else if (wake == 3){
-			DDRB |= IR;//Set direction out
-			PORTB |= IR;//Set pin on
+			PORTB |= IR;//Set pin on - Always set high before switching to output or will will short out Vcc to ground!
+			DDRB |= IR;//Set direction out		
 			sendColor(LEDCLK, LEDDAT, wakeColor);
 			startTime = timer;
 			wake = 4;

--- a/avr/cores/AutomaTile/main.c
+++ b/avr/cores/AutomaTile/main.c
@@ -3,6 +3,8 @@
 #include "color.h"
 #include "APA102C.h"
 
+#include <util/delay.h>
+
 uint32_t prevTimer;
 const rgb black = {0x00, 0x00, 0x00};
 const rgb transmitColor = {0xff, 0x55, 0x00};
@@ -12,6 +14,20 @@ static uint8_t seqNum = 0;//Sequence number used to prevent circular retransmiss
 
 int main(void) {
 	tileSetup();
+
+	// Power on sequence - 3 short blue blinks
+	// so we can visually see when a reset happens
+
+	static rgb powerupColor = {0,0,255};
+
+	uint8_t i=3;
+	while (i--) {
+		sendColor(LEDCLK, LEDDAT, powerupColor );
+		_delay_ms(200);
+		sendColor(LEDCLK, LEDDAT, black );
+		_delay_ms(200);
+		
+	}
 
 	setup();
 


### PR DESCRIPTION
Makes it possible to see unintentional Resets while running, and fixes a case where power can be shorted to ground and so closes #10.